### PR TITLE
Fix: Change host port from 5000 to 5001 to resolve conflict

### DIFF
--- a/badgereader_addon/config.yaml
+++ b/badgereader_addon/config.yaml
@@ -12,6 +12,6 @@ arch:
 startup: services
 boot: auto
 ports:
-  5000/tcp: 5000 # Assuming the API runs on port 5000, will verify this later
+  5000/tcp: 5001 # Assuming the API runs on port 5000, will verify this later
 options: {}
 schema: {}


### PR DESCRIPTION
The add-on was failing to start due to port 5000 already being in use on the host system. This change modifies the add-on's configuration to map host port 5001 to the container's port 5000, resolving the conflict.