### PR TITLE
Refactor: Update Dockerfile and run script

### DIFF
--- a/badgereader_addon/Dockerfile
+++ b/badgereader_addon/Dockerfile
@@ -2,9 +2,6 @@ ARG BUILD_FROM
 FROM $BUILD_FROM
 
 # Install requirements for add-on
-RUN \
-  apk add --no-cache \
-      python3
 
 # Set the working directory
 WORKDIR /usr/src/app

--- a/badgereader_addon/run.sh
+++ b/badgereader_addon/run.sh
@@ -4,7 +4,7 @@ bashio::log.info "NFC Badge Reader Addon starting..."
 
 # Start the Python HTTP server
 bashio::log.info "Starting Python HTTP server for badge messages..."
-python3 /badgereader_addon/server.py
+python /badgereader_addon/server.py
 
 # If server.py exits, log it and keep container alive for debugging if needed,
 # though ideally server.py runs forever.


### PR DESCRIPTION
Removes the explicit installation of python3 from the Dockerfile, as the base image is expected to have a python interpreter.

Updates the run.sh script to use `python` instead of `python3` to execute the server, making it more portable across environments where `python` is the standard command.